### PR TITLE
keyboardのEnter(search)時にサーチバーが初期化されてしまう不具合修正

### DIFF
--- a/Root/Sources/Proposal/View/ProposalListContainerView.swift
+++ b/Root/Sources/Proposal/View/ProposalListContainerView.swift
@@ -97,7 +97,7 @@ public final class ProposalListViewModel: ObservableObject {
 
     struct Content: Equatable {
         var allProposals: [Proposal] // For data-source
-        var searchQuery: String = " " // 初期値が空文字にするとsubmit時にサーチバーがクリアされる不具合があるため半角を入れておく
+        var searchQuery: String = " " // 💡 初期値が空文字にするとsubmit時にサーチバーがクリアされる不具合があるため半角を入れておく
 
         init(proposals: [Proposal]) {
             allProposals = proposals


### PR DESCRIPTION
引数に渡ってきたcontent.searchQueryをBindingから参照せずに、viewModel経由でcontentを参照することで再現しなくなった。
コードがブラックボックスな為、厳密な原因特定は難しそうだった。

![Simulator Screen Recording - iPhone 13 - 2022-03-19 at 22 19 53](https://user-images.githubusercontent.com/14083051/159122854-b6b2e6de-4222-492a-abc9-c14ba779cc0e.gif)

 # 追記: ワークアラウンドとしてシンプルなこちらの方法を採用
> 信じられないだろうけど、query の初期文字列を変更しただけで、テキストボックスがクリアされる症状は起きなくなったw
![image](https://user-images.githubusercontent.com/14083051/159123350-a14fbe13-9493-417f-96b7-5b47be6f234f.png)

