### PR TITLE
Networkエラーを修正

### DIFF
--- a/Root/Sources/SwiftEvolutionAPI/Responses.swift
+++ b/Root/Sources/SwiftEvolutionAPI/Responses.swift
@@ -210,6 +210,7 @@ public enum Resolution: String, Codable, Equatable {
 
 public enum StatusEnum: String, Codable, Equatable {
     case closed = "Closed"
+    case empty = ""
     case inProgress = "In Progress"
     case resolved = "Resolved"
     case statusOpen = "Open"


### PR DESCRIPTION
## What

macのApp Storeよりアプリを入れてみたところネットワークエラーが発生しており、情報が見れない状態になっていました。

<img width="790" alt="image" src="https://user-images.githubusercontent.com/9880704/170685126-768350b9-205f-4bd0-8789-8b6ca7d32e77.png">

## Why

プロポーザルの情報を取得しているURL（ https://data.swift.org/swift-evolution/proposals ）のレスポンスに含まれる`trackingBugs`内の`status`が空文字を返していますが、デコード時のenum（`StatusEnum`）に空文字を表す値がないためJSONのデコードに失敗しています。

```swift
public struct TrackingBug: Codable, Equatable {
    public var assignee: String
    public var id: String
    public var link: String
    public var radar: String
    public var resolution: Resolution
    public var status: StatusEnum
    public var title: String
    public var updated: String
    ...
}

public enum StatusEnum: String, Codable, Equatable {
    case closed = "Closed"
    case inProgress = "In Progress"
    case resolved = "Resolved"
    case statusOpen = "Open"
}
```

## How

`Resolution`の実装を参考に、`StatusEnum`にも同様に空文字を表すcaseの`empty`を追加しました。

iOS Simulatorでエラーが解消されていることを確認しました。

![Simulator Screen Shot - iPhone 13 Pro](https://user-images.githubusercontent.com/9880704/170686628-09de7eb3-b0f1-4e1d-b013-ceb24cb26ed9.png)

## Memo

https://github.com/YusukeHosonuma/Swift-Evolution-Browser/issues/78 で言及されている内容が`StatusEnum`も対象にしている場合、このPRの修正は不適切かも知れません。
